### PR TITLE
feat(component-tester) first working version (based on webpack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-typedoc": "^1.2.1",
     "gulp-typedoc-extractor": "^0.0.8",
     "jasmine-core": "^2.1.3",
+    "jquery": "^2.2.3",
     "karma": "^0.13.15",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chrome-launcher": "^0.1.7",

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -1,0 +1,30 @@
+beforeEach(function () {
+  function boolMatcher(match) {
+    return function () {
+      return {
+        compare: function (actual, expected) {
+          return {
+            pass: match(actual, expected)
+          }
+        }
+      }
+    }
+  }
+
+  jasmine.addMatchers({
+    //actual is expected to be a jquery object
+    toBeVisible: boolMatcher((actual)=>
+      actual.length > 0 && !actual.hasClass('aurelia-hide') && actual.filter(":visible").length === actual.length
+    ),
+
+    //actual is expected to be a jquery object
+    toBeHidden: boolMatcher(
+      //if.bind does not generate the dom element, so a zero length selector is normal
+      (actual)=>actual.length === 0 ||
+
+        //show.bind set the class
+      actual.hasClass('aurelia-hide')
+    )
+  });
+});
+

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,0 +1,7 @@
+var Promise = require('bluebird');
+Promise.config({warnings: false});
+
+import './integrated/matchers';
+
+import {initialize} from 'aurelia-pal-browser';
+initialize();

--- a/src/test_index.js
+++ b/src/test_index.js
@@ -1,0 +1,5 @@
+var testsContext = require.context(".", true, /setup.js/);
+testsContext(testsContext.keys()[0]);
+
+testsContext = require.context(".", true, /.spec.js/);
+testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
This PR is a first working version of `ComponentTester` and includes :
- The `ComponentTester` class
- A set of Aurelia specific jasmine matchers
- Files to help setup tests in an existing weback based project (`setup.js` and `test_index.js`)

A basic test using `ComponentTester` looks like this:

```
import {ComponentTester} from "./integrated/component-tester";
describe('User component', () => {

  it('should show user name', done => {

    ComponentTester.load({
      type: 'user',
      markup: `<user user.bind="currentUser"></user>`,
      setupBindingContext: (context, container)=> {
        context.currentUser = {
          login: 'defunkt',
          avatar_url: 'https://avatars.githubusercontent.com/u/2?v=3',
          html_url: 'https://github.com/defunkt',
        };
      }
    }).then(tester=> {
      let value = tester.$el.find('p.name');
      expect(value).toBeVisible();
      expect(value.text()).toBe('defunkt');
      tester.dispose(done);
    });

  });
});
```

Ref: https://github.com/aurelia/testing/issues/1
