### PR TITLE
feat(component-tester): support lifecycle testing

### DIFF
--- a/src/component-tester.js
+++ b/src/component-tester.js
@@ -1,4 +1,5 @@
 import {bootstrap} from 'aurelia-bootstrapper';
+import {View} from 'aurelia-templating';
 
 export const StageComponent = {
   withResources(resources): ComponentTester {
@@ -7,28 +8,39 @@ export const StageComponent = {
 };
 
 export class ComponentTester {
+  bind: {(bindingContext: any): void };
+  attached: {(): void };
+  unbind: {(): void };
+  dispose: {(): Promise<any> };
+  element: Element;
+  viewModel: any;
   _html: string;
   _resources: string | string[] = [];
   _bindingContext: any;
+  _rootView: View;
   _configure = aurelia => aurelia.use.standardConfiguration();
-  element;
 
   bootstrap(configure: (aurelia: Aurelia) => void) {
     this._configure = configure;
   }
 
-  withResources(resources): ComponentTester {
+  withResources(resources: string | string[]): ComponentTester {
     this._resources = resources;
     return this;
   }
 
-  inView(html): ComponentTester {
+  inView(html: string): ComponentTester {
     this._html = html;
     return this;
   }
 
-  boundTo(bindingContext): ComponentTester {
+  boundTo(bindingContext: any): ComponentTester {
     this._bindingContext = bindingContext;
+    return this;
+  }
+
+  manuallyHandleLifecycle(): ComponentTester {
+    this._prepareLifecycle();
     return this;
   }
 
@@ -36,17 +48,53 @@ export class ComponentTester {
     return bootstrap(aurelia => {
       return Promise.resolve(this._configure(aurelia)).then(() => {
         aurelia.use.globalResources(this._resources);
-
         return aurelia.start().then(a => {
           let host = document.createElement('div');
           host.innerHTML = this._html;
-
           document.body.appendChild(host);
           aurelia.enhance(this._bindingContext, host);
-
+          this._rootView = aurelia.root;
           this.element = host.firstElementChild;
+          this.viewModel = this.element.au.controller.viewModel;
+          this.dispose = () => host.parentNode.removeChild(host);
+          return new Promise(resolve => setTimeout(() => resolve(), 0));
         });
       });
+    });
+  }
+
+  _prepareLifecycle() {
+    // bind
+    const bindPrototype = View.prototype.bind;
+    View.prototype.bind = () => {};
+    this.bind = bindingContext => new Promise(resolve => {
+      View.prototype.bind = bindPrototype;
+      if (bindingContext !== undefined) {
+        this._bindingContext = bindingContext;
+      }
+      this._rootView.bind(this._bindingContext);
+      setTimeout(() => resolve(), 0);
+    });
+
+    // attached
+    const attachedPrototype = View.prototype.attached;
+    View.prototype.attached = () => {};
+    this.attached = () => new Promise(resolve => {
+      View.prototype.attached = attachedPrototype;
+      this._rootView.attached();
+      setTimeout(() => resolve(), 0);
+    });
+
+    // detached
+    this.detached = () => new Promise(resolve => {
+      this._rootView.detached();
+      setTimeout(() => resolve(), 0);
+    });
+
+    // unbind
+    this.unbind = () => new Promise(resolve => {
+      this._rootView.unbind();
+      setTimeout(() => resolve(), 0);
     });
   }
 }


### PR DESCRIPTION
Adding support for lifecycle testing.

Given you have following custom element:

``` html
<template>
  <div class="name">${name} ${something}</div>
</template>
```

``` javascript
import {bindable} from 'aurelia-framework';

export class MyComponent {
  @bindable name;

  bind() {
    this.something = 'bind';
  }

  attached() {
    this.something = 'attached';
  }

  unbind() {
   this.name = null;
  }

  detached() {
  }
}
```

Some basic tests could look like:

``` javascript
import {StageComponent} from 'aurelia-testing';
import {MyComponent} from '../src/my-component';

describe('MyComponent', () => {
  let component;

  beforeEach(() => {
    component = StageComponent
        .withResources('src/my-component')
        .inView('<my-component name.bind="name"></my-component>')
        .boundTo({ name: 'Foo' });
  });

  afterEach(() => {
    component.dispose();
  });

  it('can render the component', done => {
     component.create()
     .then(() => {
       const nameElement = document.querySelector('.name');
       expect(nameElement.innerHTML).toBe('Foo attached');
     })
    .then(done);
  });

  it('can bind with a new context', done => {
     component.boundTo({ name: 'Bar' }).create()
     .then(() => {
       const nameElement = document.querySelector('.name');
       expect(nameElement.innerHTML).toBe('Bar attached');
     })
     .then(done);
  });

  it('can manually handle lifecycle', done => {
    let nameElement;

     component.manuallyHandleLifecycle().create()
     .then(() => {
       nameElement = document.querySelector('.name');
       expect(nameElement.innerHTML).toBe(' ');
     })
     .then(() => component.bind())
     .then(() => {
       expect(nameElement.innerHTML).toBe('Foo bind');
     })
     .then(() => component.attached())
     .then(() => {
       expect(nameElement.innerHTML).toBe('Foo attached');
     })
     .then(() => component.detached())
     .then(() => component.unbind())
     .then(() => {
       expect(component.viewModel.name).toBe(null);
     })
     .then(() => component.bind({ name: 'Bar' }))
     .then(() => {
       expect(nameElement.innerHTML).toBe('Bar bind');
     })
     .then(() => component.attached())
     .then(() => {
       expect(nameElement.innerHTML).toBe('Bar attached');
     })
     .then(done);
  }); 
});
```
