### PR TITLE
Updated unit test docs to reflect skeletons

### DIFF
--- a/doc/article/en-US/testing-components.md
+++ b/doc/article/en-US/testing-components.md
@@ -67,7 +67,7 @@ In order to test that the component renders expected HTML, based on what the vie
 
       beforeEach(() => {
         component = StageComponent
-          .withResources('src/my-component')
+          .withResources('my-component')
           .inView('<my-component first-name.bind="firstName"></my-component>')
           .boundTo({ firstName: 'Bob' });
       });


### PR DESCRIPTION
The skeleton and the cli generated start do not work when prefixing resources with `src/`.
Using it accordingly in the docs will avoid confusion.