### PR TITLE
fix(typings): Typings for StageComponent

### DIFF
--- a/src/component-tester.js
+++ b/src/component-tester.js
@@ -1,11 +1,11 @@
 import {View} from 'aurelia-templating';
 import {Aurelia} from 'aurelia-framework';
 
-export const StageComponent = {
-  withResources(resources): ComponentTester {
+export class StageComponent {
+  static withResources(resources: string | string[]): ComponentTester {
     return new ComponentTester().withResources(resources);
   }
-};
+}
 
 export class ComponentTester {
   bind: (bindingContext: any) => void;

--- a/src/component-tester.js
+++ b/src/component-tester.js
@@ -43,7 +43,7 @@ export class ComponentTester {
     return this;
   }
 
-  create(bootstrap: (aurelia: Aurelia) => Promise<void>): Promise<void> {
+  create(bootstrap: (configure: (aurelia: Aurelia) => Promise<void>) => Promise<void>): Promise<void> {
     return bootstrap(aurelia => {
       return Promise.resolve(this.configure(aurelia)).then(() => {
         if (this._resources) {


### PR DESCRIPTION
Corrected the typings for StageComponent and ComponentTester
I had to turn StageComponent into a class with a static withResources() as the const would have been transformed into `any` when generating the d.ts file.