### PR TITLE
feat(http-client): Created http client mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "aurelia-pal": "^1.0.0"
     },
     "dependencies": {
+      "mock-xhr": "^0.1.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-framework": "^1.0.0",
       "aurelia-logging": "^1.0.0",
@@ -52,6 +53,7 @@
     }
   },
   "dependencies": {
+    "mock-xhr": "^0.1.0",
     "aurelia-templating": "^1.0.0",
     "aurelia-framework": "^1.0.0",
     "aurelia-dependency-injection": "^1.0.0",

--- a/src/aurelia-testing.js
+++ b/src/aurelia-testing.js
@@ -1,6 +1,7 @@
 import {CompileSpy} from './compile-spy';
 import {ViewSpy} from './view-spy';
 import {StageComponent, ComponentTester} from './component-tester';
+import {HttpClientMock} from './http-client-mock';
 import {waitFor, waitForDocumentElement, waitForDocumentElements} from './wait';
 
 function configure(config) {
@@ -15,6 +16,7 @@ export {
   ViewSpy,
   StageComponent,
   ComponentTester,
+  HttpClientMock,
   configure,
   waitFor,
   waitForDocumentElement,

--- a/src/expectation-builder.js
+++ b/src/expectation-builder.js
@@ -1,0 +1,85 @@
+import {Expectation} from './expectation';
+
+export class ExpectationBuilder {
+
+  /**
+   * @param handler {RequestHandler}
+   */
+  constructor(handler) {
+    this.expectation = new Expectation();
+    // Set reference to handler
+    handler.expect(this.expectation);
+  }
+
+  /**
+   * Expect an url to be called
+   * @param url {String}
+   * @returns {ExpectationBuilder}
+   */
+  withUrl(url) {
+    this.expectation.url = url;
+    return this;
+  }
+
+  /**
+   * Expect the request to be done with a specific method
+   * @param method {String}
+   * @returns {ExpectationBuilder}
+   */
+  withMethod(method) {
+    this.expectation.method = method;
+    return this;
+  }
+
+  /**
+   * Expect the request to contain certain header
+   * @param name {String}
+   * @param value {String}
+   * @returns {ExpectationBuilder}
+   */
+  withRequestHeader(name, value) {
+    this.expectation.requestHeaders[name.toLocaleLowerCase()] = value;
+    return this;
+  }
+
+  /**
+   * Expect the request to send specific data
+   * @param body {String}
+   * @returns {ExpectationBuilder}
+   */
+  withRequestBody(body) {
+    this.expectation.requestBody = typeof body === 'string' ? body : JSON.stringify(body);
+    return this;
+  }
+
+  /**
+   * Expect the request to respond with specific http status code
+   * @param status {Number}
+   * @returns {ExpectationBuilder}
+   */
+  withResponseStatus(status) {
+    this.expectation.responseStatus = status;
+    return this;
+  }
+
+  /**
+   * Expect the response to contain a certain header
+   * @param name {String}
+   * @param value {String}
+   * @returns {ExpectationBuilder}
+   */
+  withResponseHeader(name, value) {
+    this.expectation.responseHeaders[name.toLocaleLowerCase()] = value;
+    return this;
+  }
+
+  /**
+   * Expect the response to contain specific data
+   * @param body {String|Object}
+   * @returns {ExpectationBuilder}
+   */
+  withResponseBody(body) {
+    this.expectation.responseBody = typeof body === 'string' ? body : JSON.stringify(body);
+    return this;
+  }
+}

--- a/src/expectation.js
+++ b/src/expectation.js
@@ -1,0 +1,55 @@
+
+export class Expectation {
+
+  url = null;
+
+  method = null;
+
+  requestHeaders = {};
+
+  requestBody = null;
+
+  responseStatus = 200;
+
+  responseHeaders = {};
+
+  responseBody = '';
+
+  /**
+   * @param xhr {XHRMock}
+   * @returns {Boolean}
+   */
+  matches(xhr) {
+    if (this.url && xhr.url !== this.url) {
+      return false;
+    }
+    if (this.method && xhr.method !== this.method) {
+      return false;
+    }
+    if (!this._compareObjects(this.requestHeaders, xhr.requestHeaders)) {
+      return false;
+    }
+
+    return !(this.requestBody && xhr.requestText !== this.requestBody);
+  }
+
+  /**
+   * @param object1 {Object}
+   * @param object2 {Object}
+   * @returns {Boolean}
+   * @private
+   */
+  _compareObjects(object1, object2) {
+    if (Object.keys(object1).length) {
+      for (let key in object1) {
+        if (!object1.hasOwnProperty(key)) {
+          continue;
+        }
+        if (!object2[key] || object2[key] !== object1[key]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/src/http-client-mock.js
+++ b/src/http-client-mock.js
@@ -1,0 +1,87 @@
+import {Container} from 'aurelia-dependency-injection';
+import * as http from 'aurelia-http-client';
+import {request as XHRMock} from 'mock-xhr';
+import {RequestHandler} from './request-handler';
+import {ExpectationBuilder} from './expectation-builder';
+
+export class HttpClientMock extends http.HttpClient {
+
+  /**
+   * @constructor
+   */
+  constructor() {
+    super();
+
+    let handler = this.handler = new RequestHandler();
+    // Ensure each http client has it's own xhr mock instance with it's own handler
+    function XHR() {
+      XHRMock.apply(this, arguments);
+      this.upload = {};
+      this.onsend = () => handler.handle(this);
+    }
+    XHR.prototype = XHRMock.prototype;
+    // Create message processor with xhr mock
+    this.requestProcessorFactories = new Map();
+    this.requestProcessorFactories.set(http.HttpRequestMessage, () => HttpClientMock.createMockProcessor(XHR));
+    this.requestProcessorFactories.set(http.JSONPRequestMessage, () => HttpClientMock.createMockProcessor(XHR));
+  }
+
+  /**
+   * @param xhr {XHRMock}
+   * @returns {http.RequestMessageProcessor}
+   */
+  static createMockProcessor(xhr) {
+    return new http.RequestMessageProcessor(xhr, [
+      http.timeoutTransformer,
+      http.credentialsTransformer,
+      http.progressTransformer,
+      http.responseTypeTransformer,
+      http.headerTransformer,
+      http.contentTransformer
+    ]);
+  }
+
+  /**
+   * @void
+   */
+  registerGlobally() {
+    new Container().makeGlobal();
+    Container.instance.registerInstance(http.HttpClient, this);
+  }
+
+  /**
+   * @param url {String}
+   * @returns {ExpectationBuilder}
+   */
+  expect(url) {
+    return new ExpectationBuilder(this.handler).withUrl(url);
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+  isDone() {
+    return this.handler.isDone();
+  }
+
+  /**
+   * @returns {Array<Expectation>}
+   */
+  getExpected() {
+    return this.handler.expected;
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+  hadUnexpected() {
+    return this.handler.hadUnexpected();
+  }
+
+  /**
+   * @returns {Array<XHRMock>}
+   */
+  getUnexpected() {
+    return this.handler.unexpected;
+  }
+}

--- a/src/request-handler.js
+++ b/src/request-handler.js
@@ -1,0 +1,55 @@
+
+export class RequestHandler {
+
+  /**
+   * @type {Array<Expectation>}
+   */
+  expected = [];
+
+  /**
+   * @type {Array<XHRMock>}
+   */
+  unexpected = [];
+
+  /**
+   * @param expected {Expectation}
+   */
+  expect(expected) {
+    this.expected.push(expected);
+  }
+
+  /**
+   * @param xhr {XHRMock}
+   */
+  handle(xhr) {
+    for (let i = this.expected.length; i--;) {
+      let expected = this.expected[i];
+      // Compare url and http method
+      if (expected.matches(xhr)) {
+        // Set expected response headers on xhr mock
+        xhr.responseHeaders = expected.responseHeaders || {};
+        // Emulate response with expected values
+        xhr.receive(expected.responseStatus, expected.responseBody);
+        // Remove the expected request because we handle it only once
+        this.expected.splice(i, 1);
+        return;
+      }
+    }
+    // No expected request was found if the function hasn't returned yet
+    this.unexpected.push(xhr);
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+  isDone() {
+    return !this.expected.length;
+  }
+
+  /**
+   * @returns {Boolean}
+   */
+  hadUnexpected() {
+    return !!this.unexpected.length;
+  }
+}


### PR DESCRIPTION
Hey guys,

during my app development I came to an point where I wanted to write tests for all my components and stuck at those which communicate with our backend via http client. It was hard to test these components and there behavior and therefore I wrote a mock for the HttpClient based on mock-xhr. This mock provides the ability to test the outgoing request for it's headers, method and request body and emulate the backend response with it's status code, response headers and response body to test the complete flow.

If we want to drive this mock more forward we (probably just me) could also remove the dependency on mock-xhr and create a small self written mock.

Here is an example usage:
```js
import {HttpClientMock} from 'aurelia-testing';
import {ViewModel} from 'somewhere/in/my/application/view-model';

describe('A ViewModel', function() {
  /** @type Element */
  let host;
  /** @type HttpClientMock */
  let http;
  /** @type ViewModel */
  let vm;

  beforeEach(function() {
    http = new HttpClientMock();
    // Usefull for code which uses the Container.instance.get() fn
    http.registerGlobally();
    host = document.createElement('div');
    vm = new ViewModel(host, http, {tr: () => ''});
  });
  // After each test we expect that all expeced urls were called and no unexpected calls happened
  afterEach(function() {
    let expectedUrls = httpMock.getExpected().map(stringifyXhr);
    expect(httpMock.isDone()).toBeTruthy('Never called urls: \n' + expectedUrls.join('\n'));
    let unexpectedUrls = httpMock.getUnexpected().map(stringifyXhr);
    expect(httpMock.hadUnexpected()).toBeFalsy('Unexpected calls: \n' + unexpectedUrls.join('\n'));
  });

  it('call some backend url', function(done) {
    http.expect(`/backend/some/resource`)
          .withMethod('POST')
          .withRequestHeader('Authorization', 'Bearer some-token')
          .withRequestBody(requestData)
          .withResponseStatus(204)
          .withResponseHeader('Location', 'http://this.is/the/location/to/the/resource/1111');

    vm.submit().then(done)
  });
});

```

Pls feel free to comment on this and suggest improvements.
I think this could either go into this package or an aurelia-http-client-mock package or even into the aurelia-http-client.

Could someone of you pls review that?
@EisenbergEffect 

Best
Thomas