### PR TITLE
fix(ComponentTester): import missing waitFor function

### DIFF
--- a/src/component-tester.js
+++ b/src/component-tester.js
@@ -1,5 +1,6 @@
 import {View} from 'aurelia-templating';
 import {Aurelia} from 'aurelia-framework';
+import {waitFor} from './wait';
 
 export class StageComponent {
   static withResources(resources?: string | string[]): ComponentTester {

--- a/test/component-tester.spec.js
+++ b/test/component-tester.spec.js
@@ -1,0 +1,41 @@
+import {StageComponent} from '../src/component-tester';
+import {bootstrap} from 'aurelia-bootstrapper';
+
+describe('ComponentTester', () => {
+  let component;
+
+  beforeEach(() => {
+    component = StageComponent
+      .withResources('test/resources/my-component')
+      .inView(`<div>
+                 <div class="component-tester-spec">
+                   <my-component first-name.bind="firstName"></my-component>
+                 </div>
+                 <div class="component-tester-spec">
+                   Number two
+                 </div>
+               </div>`)
+      .boundTo({ firstName: 'Bob' });
+  });
+
+  it('should wait for a child element', (done) => {
+    component.create(bootstrap).then(() => {
+      component.waitForElement('my-component').then((element) => {
+        expect(element.nodeName.toLowerCase()).toEqual('my-component');
+        done();
+      });
+    });
+  });
+
+  it('should wait for multiple child elements', (done) => {
+    component.create(bootstrap).then(() => {
+      component.waitForElements('.component-tester-spec').then((elements) => {
+        expect(elements.length).toBe(2);
+        done();
+      });
+    });
+  });
+  afterEach(() => {
+    component.dispose();
+  });
+});


### PR DESCRIPTION
Fixes aurelia/testing#59

- Resolves issue when using ComponentTester.waitForElement(s)
- Started a ComponentTester spec; implemented methods that verify
this fix.