### PR TITLE
fix(code example): fix to the manually handling lifecycle example

### DIFF
--- a/doc/article/en-US/testing-components.md
+++ b/doc/article/en-US/testing-components.md
@@ -128,7 +128,7 @@ When testing a component sometimes you want to have tests run at certain points 
       it('can manually handle lifecycle', done => {
         let nameElement;
 
-        component.manuallyHandleLifecycle().create()
+        component.manuallyHandleLifecycle().create(bootstrap)
           .then(() => {
             nameElement = document.querySelector('.name');
             expect(nameElement.innerHTML).toBe(' ');


### PR DESCRIPTION
I was trying to following this example and it wasn't working. Looking at the other examples in the guide it appears you need to pass in the bootstrap method when you call `component.create()`.