### PR TITLE
rfc(error): improve timeout error stack trace for waitFor timeouts

### DIFF
--- a/dist/amd/wait.js
+++ b/dist/amd/wait.js
@@ -32,10 +32,12 @@ define(["require", "exports"], function (require, exports) {
             }
             return new Promise(function (rs) { return setTimeout(rs, options.interval); }).then(wait);
         }
+        // We generate the error here to capture the stack trace, but we will only throw it if it times out
+        var timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
         return Promise.race([
             new Promise(function (_, rj) { return setTimeout(function () {
                 timedOut = true;
-                rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+                rj(timeoutError);
             }, options.timeout); }),
             wait()
         ]);

--- a/dist/commonjs/wait.js
+++ b/dist/commonjs/wait.js
@@ -31,10 +31,12 @@ function waitFor(getter, options) {
         }
         return new Promise(function (rs) { return setTimeout(rs, options.interval); }).then(wait);
     }
+    // We generate the error here to capture the stack trace, but we will only throw it if it times out
+    var timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
     return Promise.race([
         new Promise(function (_, rj) { return setTimeout(function () {
             timedOut = true;
-            rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+            rj(timeoutError);
         }, options.timeout); }),
         wait()
     ]);

--- a/dist/es2015/wait.js
+++ b/dist/es2015/wait.js
@@ -20,10 +20,12 @@ export function waitFor(getter, options = { present: true, interval: 50, timeout
         }
         return new Promise(rs => setTimeout(rs, options.interval)).then(wait);
     }
+    // We generate the error here to capture the stack trace, but we will only throw it if it times out
+    const timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
     return Promise.race([
         new Promise((_, rj) => setTimeout(() => {
             timedOut = true;
-            rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+            rj(timeoutError);
         }, options.timeout)),
         wait()
     ]);

--- a/dist/es2017/wait.js
+++ b/dist/es2017/wait.js
@@ -20,10 +20,12 @@ export function waitFor(getter, options = { present: true, interval: 50, timeout
         }
         return new Promise(rs => setTimeout(rs, options.interval)).then(wait);
     }
+    // We generate the error here to capture the stack trace, but we will only throw it if it times out
+    const timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
     return Promise.race([
         new Promise((_, rj) => setTimeout(() => {
             timedOut = true;
-            rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+            rj(timeoutError);
         }, options.timeout)),
         wait()
     ]);

--- a/dist/native-modules/wait.js
+++ b/dist/native-modules/wait.js
@@ -29,10 +29,12 @@ export function waitFor(getter, options) {
         }
         return new Promise(function (rs) { return setTimeout(rs, options.interval); }).then(wait);
     }
+    // We generate the error here to capture the stack trace, but we will only throw it if it times out
+    var timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
     return Promise.race([
         new Promise(function (_, rj) { return setTimeout(function () {
             timedOut = true;
-            rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+            rj(timeoutError);
         }, options.timeout); }),
         wait()
     ]);

--- a/dist/system/wait.js
+++ b/dist/system/wait.js
@@ -32,10 +32,12 @@ System.register([], function (exports_1, context_1) {
             }
             return new Promise(function (rs) { return setTimeout(rs, options.interval); }).then(wait);
         }
+        // We generate the error here to capture the stack trace, but we will only throw it if it times out
+        var timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
         return Promise.race([
             new Promise(function (_, rj) { return setTimeout(function () {
                 timedOut = true;
-                rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+                rj(timeoutError);
             }, options.timeout); }),
             wait()
         ]);

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -34,11 +34,14 @@ export function waitFor<T>(getter: () => T, options: {
     return new Promise(rs => setTimeout(rs, options.interval)).then(wait);
   }
 
+  // We generate the error here to capture the stack trace, but we will only throw it if it times out
+  const timeoutError = new Error(options.present ? 'Element not found' : 'Element not removed');
+
   return Promise.race([
     new Promise(
       (_, rj) => setTimeout(() => {
         timedOut = true;
-        rj(new Error(options.present ? 'Element not found' : 'Element not removed'));
+        rj(timeoutError);
       }, options.timeout)
     ),
     wait()


### PR DESCRIPTION
Edit: I originally posted a gross hacky version but I think I found a passable solution like 15 minutes after posting the pull request and have force pushed that now

----

Full disclosure, I have no idea if this is a horrible idea or not 🙃 

We have a _stack_ of waitFor calls in our tests and while I was stumbling trying to resolve some problematic tests, I was frustrated that the stack trace of the exception was incredibly vague:

```
Error: Element not found

    at Timeout._onTimeout (/Users/tom/src/my-cool-app/node_modules/aurelia-testing/dist/commonjs/wait.js:67:10)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```

Even when I used a debugger, it was incredibly difficult to track down _which_ waitFor call was causing me grief. After my solution I got a stack trace that helped my track down the specific failing call:

```
Error: Element not found

    at Object.waitFor (/Users/tom/src/my-cool-app/node_modules/aurelia-testing/dist/commonjs/wait.js:35:22)
    at /Users/tom/src/my-cool-app/assets/test/my-cool-component.spec.ts:144:39
    at step (/Users/tom/src/my-cool-app/assets/test/my-cool-component.spec.ts:33:23)
    at Object.next (/Users/tom/src/my-cool-app/assets/test/my-cool-component.spec.ts:14:53)
    at fulfilled (/Users/tom/src/my-cool-app/assets/test/my-cool-component.spec.ts:5:58)
```

Again, not sure if this is a terrible way to do this (I'm running this in node with js-dom, not sure about other setups?), but I hope it at least starts a conversation - maybe I'm missing something else that's simple?